### PR TITLE
商品を削除する機能を実装

### DIFF
--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -34,6 +34,12 @@ class ExhibitsController < ApplicationController
     end
   end
 
+  def destroy
+    exhibit = Exhibit.find(params[:id])
+    exhibit.destroy
+    redirect_to root_path
+  end
+
   private
 
   def exhibit_params

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -1,7 +1,7 @@
 class ExhibitsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_exhibit, only: [:show, :edit, :update]
-  before_action :contributor_confirmation, only: [:edit, :update]
+  before_action :contributor_confirmation, only: [:edit, :update, :destroy]
 
   def index
     @exhibits = Exhibit.order('created_at DESC')

--- a/app/controllers/exhibits_controller.rb
+++ b/app/controllers/exhibits_controller.rb
@@ -1,6 +1,6 @@
 class ExhibitsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_exhibit, only: [:show, :edit, :update]
+  before_action :set_exhibit, only: [:show, :edit, :update, :destroy]
   before_action :contributor_confirmation, only: [:edit, :update, :destroy]
 
   def index
@@ -35,8 +35,7 @@ class ExhibitsController < ApplicationController
   end
 
   def destroy
-    exhibit = Exhibit.find(params[:id])
-    exhibit.destroy
+    @exhibit.destroy
     redirect_to root_path
   end
 

--- a/app/views/exhibits/show.html.erb
+++ b/app/views/exhibits/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user == @exhibit.user %>
       <%= link_to "商品の編集", edit_exhibit_path(@exhibit), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", exhibit_path(@exhibit), method: :delete, class:"item-destroy" %>
     <% end %>
 
     <% if user_signed_in? && current_user != @exhibit.user %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "exhibits#index"
-  resources :exhibits, only: [:new, :create, :show, :edit, :update]
+  resources :exhibits
 end


### PR DESCRIPTION
# What
商品の削除機能実装

#Why
都合で売れなくなったときに削除するべきだから

【 ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画】
https://gyazo.com/456aa79a83cc24158e2fc4abbc5cb848